### PR TITLE
Option to randomly cycle through preset themes

### DIFF
--- a/src/app/_storage/settings.ts
+++ b/src/app/_storage/settings.ts
@@ -34,6 +34,7 @@ export class DesignSettings {
     public customFontWeight = 40,
     public background = '#ffffff',
     public foreground = '#000000',
+    public randTheme = false,
     public colorsId = 0,
     public patternId = 0,
     public imageSize = 10,

--- a/src/app/options/design/design.component.html
+++ b/src/app/options/design/design.component.html
@@ -76,6 +76,13 @@
       </div>
     </div>
   </div>
+
+  <!-- random preset theme toggle -->
+  <div class="input">
+    <label for="randTheme">{{'options.design.randTheme' | translate}}</label>
+    <options-toggle id="randTheme" name="randTheme" [(ngModel)]="settings.config.design.randTheme" (ngModelChange)="ga.field('design.randTheme', settings.config.design.randTheme);"></options-toggle>
+  </div>
+
   <div id="themeBtns" class="grid cols-4 mt designGrid">
     <button
       *ngFor="let color of colors;"

--- a/src/app/tab/tab.component.ts
+++ b/src/app/tab/tab.component.ts
@@ -4,7 +4,7 @@ import { DomSanitizer } from '@angular/platform-browser';
 import { TranslateService } from '@ngx-translate/core';
 import { SharedService } from '../_shared/shared.service';
 import { Storage } from '../_storage/storage.service';
-import { span, bgSize, bgBlend, patterns } from '../_shared/lists/lists';
+import { span, colors, bgSize, bgBlend, patterns } from '../_shared/lists/lists';
 import { tab } from '../_shared/animations';
 
 @Component({
@@ -32,6 +32,15 @@ export class TabComponent implements OnInit, AfterViewInit {
   }
 
   ngOnInit() {
+
+    // pick a random theme
+    var c = colors[Math.floor(Math.random()*colors.length)];
+
+    this.settings.config.design.background = c.bg;
+    this.settings.config.design.foreground = c.fg;
+    this.settings.config.design.colorsId = c.id;
+
+    // rest of the initial init
     let localBgColor = this.settings.config.design.background;
     this.shared.bgColor = localBgColor;
     localStorage.setItem('ct-background', localBgColor);

--- a/src/app/tab/tab.component.ts
+++ b/src/app/tab/tab.component.ts
@@ -34,11 +34,13 @@ export class TabComponent implements OnInit, AfterViewInit {
   ngOnInit() {
 
     // pick a random theme
-    var c = colors[Math.floor(Math.random()*colors.length)];
+    if(this.settings.config.design.randTheme) {
+      var c = colors[Math.floor(Math.random()*colors.length)];
 
-    this.settings.config.design.background = c.bg;
-    this.settings.config.design.foreground = c.fg;
-    this.settings.config.design.colorsId = c.id;
+      this.settings.config.design.background = c.bg;
+      this.settings.config.design.foreground = c.fg;
+      this.settings.config.design.colorsId = c.id;
+    }
 
     // rest of the initial init
     let localBgColor = this.settings.config.design.background;

--- a/src/assets/i18n/en-US.json
+++ b/src/assets/i18n/en-US.json
@@ -159,6 +159,7 @@
       "globalSize": "Global size",
       "globalSizeDesc": "Adjust the size of all elements.",
       "hardToSee": "Image too hard to see? Try changing the filter.",
+      "randTheme": "Random preset theme",
       "removeWallpaper": "Click to remove selected wallpaper",
       "selectedWallpaper": "Selected wallpaper",
       "wallpaper": "Wallpaper"


### PR DESCRIPTION
## What?
There is now a toggle option in the "design" panel of Options/Settings that gives the user a choice to have their foreground & background (collectively called "theme") be randomly selected. The selection comes from 1 of many preset themes to ensure contrast and readability, and it is done every time the new tab is loaded or refreshed. 

Fixes #225 from the original repo. 

## Why?
This is a requested enhancement feature and a currently open issue: [https://github.com/bluecaret/carettab/issues/225](https://github.com/bluecaret/carettab/issues/225)

## How?

- Whether or not to randomly select a theme is saved as a configuration under `DesignSettings` and can be referred to as `this.settings.config.design.randTheme` in code. 
- Upon loading the new tab, in `tab.components.ts`'s `ngOnInit()`, if `randTheme` is on (ie `True`), then it will randomly select a color from `lists.ts`'s list of colors (by generating an index within range of the list's length), and set the theme accordingly. 
- The frontend toggle button is simply added to `design.component.html`. 

## Testing?
- Successful local dev build 
- Manual testing through clicking and refreshing
- Successful production build and loaded the extension artifact into edge to ensure the same behavior

## Screenshots
Screenshot of the toggle option in "design" panel: 
![](https://files.slack.com/files-pri/T02E7E44761-F02NQM6AT4N/screenshot.png?pub_secret=ab792ae3dc)

## Anything Else?
- Translation is needed for the "Random preset theme" blurb that appears in the "design" panel