### PR TITLE
added dark mode feature by reversing fore and background color

### DIFF
--- a/src/app/_storage/settings.ts
+++ b/src/app/_storage/settings.ts
@@ -35,6 +35,7 @@ export class DesignSettings {
     public background = '#ffffff',
     public foreground = '#000000',
     public randTheme = false,
+    public darkTheme = false,
     public colorsId = 0,
     public patternId = 0,
     public imageSize = 10,

--- a/src/app/options/design/design.component.html
+++ b/src/app/options/design/design.component.html
@@ -42,6 +42,14 @@
     <label for="scalingMethod">{{'options.design.dynScale' | translate}}<tooltip text="{{'options.design.dynScaleDesc' | translate}}"></tooltip></label>
     <options-toggle id="scalingMethod" name="scalingMethod" [(ngModel)]="settings.config.design.scalingMethod" (ngModelChange)="ga.field('design.scalingMethod', settings.config.design.scalingMethod);"></options-toggle>
   </div>
+  <!-- dark theme toggle -->
+  <div class="input">
+    <label for="darkTheme">{{'options.design.darkTheme' | translate}}</label>
+    <options-toggle id="darkTheme" name="darkTheme" [(ngModel)]="settings.config.design.darkTheme"
+      (ngModelChange)="toggleDarkMode(); ga.field('design.darkTheme', settings.config.design.darkTheme);
+      ga.field('design.foreground', settings.config.design.foreground); ga.field('design.background', settings.config.design.background);">
+    </options-toggle>
+  </div>
   <!-- Colors -->
   <h3>{{'options.design.colors' | translate}}</h3>
   <div class="input">

--- a/src/app/options/design/design.component.ts
+++ b/src/app/options/design/design.component.ts
@@ -108,6 +108,13 @@ export class OptionsDesignComponent implements OnInit {
     this.shared.echo('Pattern changed', bg);
   }
 
+  toggleDarkMode() {
+    var t = this.settings.config.design.foreground;
+    this.settings.config.design.foreground = this.settings.config.design.background;
+    this.settings.config.design.background = t;
+    this.setLocalBg(t)
+  }
+
   encodeImage(e, input) {
     let file = e.dataTransfer ? e.dataTransfer.files[0] : e.target.files[0];
     let pattern = /image-*/;

--- a/src/assets/i18n/en-US.json
+++ b/src/assets/i18n/en-US.json
@@ -160,6 +160,7 @@
       "globalSizeDesc": "Adjust the size of all elements.",
       "hardToSee": "Image too hard to see? Try changing the filter.",
       "randTheme": "Random preset theme",
+      "darkTheme": "Dark theme",
       "removeWallpaper": "Click to remove selected wallpaper",
       "selectedWallpaper": "Selected wallpaper",
       "wallpaper": "Wallpaper"


### PR DESCRIPTION
## What?
This PR implements the dark mode feature. It includes a toggle button to turn on/off dark mode, which reverses the foreground and background color
This partially implements the feature requested at [bluecaret#186](https://github.com/bluecaret/carettab/issues/186)

## Why?
This is a requested feature from [bluecaret#186](https://github.com/bluecaret/carettab/issues/186). 

## How?
The dark mode feature is implemented by a toggle button that reverses the foreground and background color customized by the user. 

## Testing?
- Successful local dev buil
- Manual testing through clicking and refreshing

## Screenshots
<img width="1006" alt="Screen Shot 2021-12-01 at 5 22 24 PM" src="https://user-images.githubusercontent.com/43523272/144323822-454d3a66-e218-4869-a33a-9e7ce465b308.png">


<!-- Read more about pull requests: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/  -->